### PR TITLE
Fix data race

### DIFF
--- a/guestbook-backend/Dockerfile
+++ b/guestbook-backend/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.8
 WORKDIR /go/src/app
 COPY . .
 
-RUN go-wrapper download   
-RUN go-wrapper install    
+RUN go-wrapper download
+RUN go-wrapper install
+RUN go test -race .
 
-CMD ["go-wrapper", "run"] 
+CMD ["go-wrapper", "run"]

--- a/guestbook-backend/guestbook.go
+++ b/guestbook-backend/guestbook.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 	"html"
 )
@@ -14,9 +15,14 @@ type Entry struct {
 	Message       string `json:"message"`
 }
 
-var guestBook []Entry
+var (
+	guestBook []Entry
+	guestBookMutex sync.Mutex
+)
 
 func guestBookHandler(response http.ResponseWriter, request *http.Request) {
+	guestBookMutex.Lock()
+	defer guestBookMutex.Unlock()
 
 	request.ParseForm()
 	if author := request.FormValue("author"); author != "" {

--- a/guestbook-backend/guestbook_test.go
+++ b/guestbook-backend/guestbook_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// NopResponseWriter does nothing at all
+type NopResponseWriter struct {}
+
+func (w NopResponseWriter) Header() http.Header {
+	return http.Header{}
+}
+
+func (w NopResponseWriter) Write(d []byte) (int, error) {
+	return len(d), nil
+}
+
+func (w NopResponseWriter) WriteHeader(int) {
+}
+
+// TestGuestBookHandlerRace invokes guestBookHandler from multiple go routines
+// in order to detect possible data races.
+func TestGuestBookHandlerRace(t *testing.T) {
+	f := func() {
+		req := http.Request{
+			Form: url.Values{},
+		}
+		req.Form.Set("author", "Heinz")
+		req.Form.Set("message", "Hello")
+		guestBookHandler(NopResponseWriter{}, &req)
+	}
+
+	// Invoke from two different go routines
+	go f()
+	go f()
+}


### PR DESCRIPTION
- Adds a simple test which invokes the handler from multiple go routines
  at once in order to find possible data races.
- Add mutex in order to avoid concurrent modification of guestBook.